### PR TITLE
Correct spec.template.metadata.labels selector

### DIFF
--- a/deploy/flask.yml
+++ b/deploy/flask.yml
@@ -34,7 +34,7 @@ spec:
   template:
     metadata:
       labels:
-         app: flask
+         run: flask
     spec:
       containers:
       - name: flask


### PR DESCRIPTION
Attempting to follow along with the book Kubernetes for Developers, I encountered the following error when attempting to apply the deployment in `flask.yml`:
```
$ kubectl apply -f flask.yml 
service "flask-service" created
configmap "flask-config" created
The Deployment "flask" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"flask"}: `selector` does not match template `labels`

```

The change purposed in the PR resolved the error (by changing the selector to match the oine in labels)